### PR TITLE
Observatory fix #52

### DIFF
--- a/src/components/blocks/Calculator.tsx
+++ b/src/components/blocks/Calculator.tsx
@@ -38,8 +38,8 @@ const Calculator = () => {
     const newInfo =
       buildings[sector].reduce(
         (acc, cv) => ({
-          workers: acc.workers + BUILDINGS[cv.id].workers,
-          power: acc.power + BUILDINGS[cv.id].power,
+          workers: acc.workers + (BUILDINGS[cv.id].workers ?? 0),
+          power: acc.power + (BUILDINGS[cv.id].power ?? 0),
           housing: acc.housing + (BUILDINGS[cv.id].housing ? BUILDINGS[cv.id].housing : 0),
           battery: acc.battery + (BUILDINGS[cv.id].battery ?? 0),
           industrySize: acc.industrySize + (BUILDINGS[cv.id].specialisation?.industry ?? 0),

--- a/src/components/blocks/Calculator.tsx
+++ b/src/components/blocks/Calculator.tsx
@@ -35,29 +35,27 @@ const Calculator = () => {
   );
 
   useEffect(() => {
-    const newInfo =
-      buildings[sector].reduce(
-        (acc, cv) => ({
-          workers: acc.workers + (BUILDINGS[cv.id].workers ?? 0),
-          power: acc.power + (BUILDINGS[cv.id].power ?? 0),
-          housing: acc.housing + (BUILDINGS[cv.id].housing ? BUILDINGS[cv.id].housing : 0),
-          battery: acc.battery + (BUILDINGS[cv.id].battery ?? 0),
-          industrySize: acc.industrySize + (BUILDINGS[cv.id].specialisation?.industry ?? 0),
-        }),
-        {
-          workers: 0,
-          power: 0,
-          housing: 0,
-          battery: 0,
-          industrySize: 0,
-        }
-      )
+    const newInfo = buildings[sector].reduce(
+      (acc, cv) => ({
+        workers: acc.workers + (BUILDINGS[cv.id].workers ?? 0),
+        power: acc.power + (BUILDINGS[cv.id].power ?? 0),
+        housing: acc.housing + (BUILDINGS[cv.id].housing ? BUILDINGS[cv.id].housing : 0),
+        battery: acc.battery + (BUILDINGS[cv.id].battery ?? 0),
+        industrySize: acc.industrySize + (BUILDINGS[cv.id].specialisation?.industry ?? 0),
+      }),
+      {
+        workers: 0,
+        power: 0,
+        housing: 0,
+        battery: 0,
+        industrySize: 0,
+      }
+    );
     if (calculateSpecialisationLevel(newInfo.industrySize, 'industry') >= 1) {
       newInfo.battery = newInfo.battery * 1.2;
     }
     setCurrentInfo(newInfo);
   }, [buildings, sector]);
-
 
   return (
     <CalculationBox>
@@ -72,7 +70,8 @@ const Calculator = () => {
           {t('housing')}: {currentInfo.housing}
         </Housing>
         <Battery>
-          {t('battery')}: {calculateBattery(currentInfo.battery, currentInfo.power)} {t('cycles')} ({currentInfo.battery})
+          {t('battery')}: {calculateBattery(currentInfo.battery, currentInfo.power)} {t('cycles')} (
+          {currentInfo.battery})
         </Battery>
       </InnerBox>
     </CalculationBox>
@@ -83,7 +82,7 @@ export default Calculator;
 
 function calculateBattery(battery: number, power: number): string {
   if (power === 0) {
-    return "0";
+    return '0';
   }
   const cycles = battery / power;
   return (Math.round(cycles * 10) / 10).toFixed(1);

--- a/src/utils/StabilityEnum.ts
+++ b/src/utils/StabilityEnum.ts
@@ -16,8 +16,8 @@ export const STABILITY_BUILD = {
     power: 6,
     workers: 10,
     specialisation: {
-      population: 28
-    }
+      population: 28,
+    },
   },
   GeneticConatusMemorial: {
     width: 7,
@@ -27,8 +27,8 @@ export const STABILITY_BUILD = {
     power: 0,
     workers: 0,
     specialisation: {
-      population: 49
-    }
+      population: 49,
+    },
   },
   LunaclysmMemorial: {
     width: 7,
@@ -38,8 +38,8 @@ export const STABILITY_BUILD = {
     power: 0,
     workers: 0,
     specialisation: {
-      population: 49
-    }
+      population: 49,
+    },
   },
   MardukMemorial: {
     width: 7,
@@ -49,8 +49,8 @@ export const STABILITY_BUILD = {
     power: 0,
     workers: 0,
     specialisation: {
-      population: 49
-    }
+      population: 49,
+    },
   },
   LawEnforcement: {
     width: 6,
@@ -68,8 +68,8 @@ export const STABILITY_BUILD = {
     power: 7,
     workers: 10,
     specialization: {
-      population: 32
-    }
+      population: 32,
+    },
   },
   Observatory: {
     width: 12,
@@ -79,8 +79,8 @@ export const STABILITY_BUILD = {
     power: 0,
     workers: 0,
     specialization: {
-      population: 36
-    }
+      population: 36,
+    },
   },
   ExoFightingDome: {
     width: 14,
@@ -90,8 +90,8 @@ export const STABILITY_BUILD = {
     power: 40,
     workers: 20,
     specialisation: {
-      population: 100
-    }
+      population: 100,
+    },
   },
 } as const;
 type STABILITY_BUILD = typeof STABILITY_BUILD[keyof typeof STABILITY_BUILD];

--- a/src/utils/StabilityEnum.ts
+++ b/src/utils/StabilityEnum.ts
@@ -69,6 +69,7 @@ export const STABILITY_BUILD = {
     workers: 10,
     specialization: {
       population: 32
+    }
   },
   Observatory: {
     width: 12,

--- a/src/utils/StabilityEnum.ts
+++ b/src/utils/StabilityEnum.ts
@@ -67,12 +67,19 @@ export const STABILITY_BUILD = {
     isWall: true,
     power: 7,
     workers: 10,
+    specialization: {
+      population: 32
   },
   Observatory: {
     width: 12,
     height: 3,
     location: [0, 0, 12, 0],
     isWall: true,
+    power: 0,
+    workers: 0,
+    specialization: {
+      population: 36
+    }
   },
   ExoFightingDome: {
     width: 14,


### PR DESCRIPTION
Adds missing data for Observatory and Hull Temple.  The specialization values entered are not verified against game resource data as I am not sure where to find that information.