### PR TITLE
NaN fix for workers power and batteries using Observatory

### DIFF
--- a/src/utils/StabilityEnum.ts
+++ b/src/utils/StabilityEnum.ts
@@ -73,6 +73,8 @@ export const STABILITY_BUILD = {
     height: 3,
     location: [0, 0, 12, 0],
     isWall: true,
+    power: 0,
+    workers: 0,
   },
   ExoFightingDome: {
     width: 14,


### PR DESCRIPTION
Updated to not enter TS (which I do not know)
When placing Observatory receiving NaN for workers, power, and battery - probably due to not checking whether there is no such parameter and then showing 0 instead of NaN

Need to check for more such errors.

Plus - there are also differences between wiki and this enum, gonna check later with copy of the game