### PR TITLE
Fix rotated-building hit-testing and selection glitches

### DIFF
--- a/src/@types/ixion.d.ts
+++ b/src/@types/ixion.d.ts
@@ -90,6 +90,7 @@ declare module 'types/Ixion' {
   interface IFindBuilding extends IPoint, IDimension {
     bx: number;
     by: number;
+    degree?: number;
   }
   interface IMinMaxAngle {
     [key: number]: ({ width, height }: IDimension) => {

--- a/src/components/atoms/TemplateBuilding.tsx
+++ b/src/components/atoms/TemplateBuilding.tsx
@@ -100,7 +100,6 @@ const TemplateBuilding = ({ construct_id, width, height, location, fillColor, te
           fill="#fff"
           textAnchor="middle"
           dominantBaseline="middle"
-          fontSizeAdjust={1}
         >
           {label.map((text, i) => (
             <tspan

--- a/src/pages/Sector/SVGContainer.tsx
+++ b/src/pages/Sector/SVGContainer.tsx
@@ -42,13 +42,13 @@ const SVGContainer = () => {
     setBuildings(prev => ({
       ...prev,
       [sectionNumber]: prev[sectionNumber].filter(
-        ({ x: bx, y: by, width, height }) => !isInsidePoint({ x, y, bx, by, width, height })
+        ({ x: bx, y: by, width, height, degree }) => !isInsidePoint({ x, y, bx, by, width, height, degree })
       ),
     }));
   };
   const moveBuilding = ({ x, y }: IPoint) => {
-    const target = buildings[sectionNumber].find(({ x: bx, y: by, width, height }) =>
-      isInsidePoint({ x, y, bx, by, width, height })
+    const target = buildings[sectionNumber].find(({ x: bx, y: by, width, height, degree }) =>
+      isInsidePoint({ x, y, bx, by, width, height, degree })
     );
     if (target === undefined) return;
     demolishBuilding({ x, y });
@@ -337,5 +337,6 @@ const SVGContainer = () => {
 const StyledContainer = styled.div`
   width: 100%;
   height: 100%;
+  user-select: none;
 `;
 export default SVGContainer;

--- a/src/utils/utilFuncs.ts
+++ b/src/utils/utilFuncs.ts
@@ -10,7 +10,7 @@ const isOverlap = ({ cur, diff }: IDiffRectangle) => {
   return true;
 };
 
-const adjustPoint = (rect: IBounds) => {
+export const adjustPoint = (rect: IBounds) => {
   if (rect.degree !== undefined && rect.degree !== 0) {
     const { x, y, width, height } = rect;
 
@@ -62,8 +62,8 @@ export const isBannerOverlap = ({ x, y, width, height }: IBounds) => {
 
   return isOverlap({ cur: building, diff: banner });
 };
-export const isInsidePoint = ({ x, y, bx, by, width, height }: IFindBuilding) => {
-  const [x1, y1, x2, y2] = [bx, by + height * GRID_HEIGHT, bx + width * GRID_WIDTH, by];
+export const isInsidePoint = ({ x, y, bx, by, width, height, degree }: IFindBuilding) => {
+  const { x1, y1, x2, y2 } = adjustPoint({ x: bx, y: by, width, height, degree });
   if (x > x1 && x < x2 && y < y1 && y > y2) return true;
   return false;
 };


### PR DESCRIPTION
Just recently finished playing Ixion and had a great time using this tool. However, while working with it, I noticed a few bugs.
This PR aims to fix them.
(p.s. I also added a couple of features but I put those in separate PRs)

- Use the rotated bounding box for move/demolish hit-testing (via adjustPoint), so clicking the edge of a rotated building no longer grabs its neighbor.
- Stop map-canvas text from being selected while clicking (user-select: none).
- Drop a stray fontSizeAdjust that oversized the drag-preview building label.