### PR TITLE
Add shift-click delete-all for buildings and roads

### DIFF
--- a/src/components/blocks/Menus/index.tsx
+++ b/src/components/blocks/Menus/index.tsx
@@ -27,8 +27,18 @@ const Menus = () => {
   const resetConstruct = useResetRecoilState(constructState);
 
   const onMenuClick = (e: React.MouseEvent<HTMLButtonElement>) => {
-    resetConstruct();
     const menuName = e.currentTarget.name;
+
+    if (e.shiftKey && (menuName === 'delBuilding' || menuName === 'delRoad')) {
+      const confirmText = t(menuName === 'delBuilding' ? 'deleteAllBuildings' : 'deleteAllRoads');
+      if (confirm(confirmText)) {
+        if (menuName === 'delBuilding') setBuildings(prev => ({ ...prev, [sectionNumber]: [] }));
+        else setRoads(prev => ({ ...prev, [sectionNumber]: [] }));
+      }
+      return;
+    }
+
+    resetConstruct();
     setClickMenu(clickMenu === menuName ? '' : menuName);
 
     if (menuName === 'consRoad') setIsVisible(true);

--- a/src/lang/lang.en.json
+++ b/src/lang/lang.en.json
@@ -1,5 +1,7 @@
 {
   "resetLayout": "Reset the layout of this sector",
+  "deleteAllBuildings": "Delete all buildings in this sector",
+  "deleteAllRoads": "Delete all roads in this sector",
   "maintenance": "MAINTENANCE",
   "space": "SPACE",
   "factories": "FACTORIES",

--- a/src/lang/lang.fr.json
+++ b/src/lang/lang.fr.json
@@ -1,5 +1,7 @@
 {
   "resetLayout": "Réinitialiser la disposition de ce secteur",
+  "deleteAllBuildings": "Supprimer tous les bâtiments de ce secteur",
+  "deleteAllRoads": "Supprimer toutes les routes de ce secteur",
   "maintenance": "MAINTENANCE",
   "space": "ESPACE",
   "factories": "USINES",

--- a/src/lang/lang.ko.json
+++ b/src/lang/lang.ko.json
@@ -1,5 +1,7 @@
 {
   "resetLayout": "이 섹터의 레이아웃을 초기화합니다.",
+  "deleteAllBuildings": "이 섹터의 모든 건물을 삭제합니다.",
+  "deleteAllRoads": "이 섹터의 모든 도로를 삭제합니다.",
   "maintenance": "정비",
   "space": "우주",
   "factories": "공장",

--- a/src/lang/lang.zh_CN.json
+++ b/src/lang/lang.zh_CN.json
@@ -1,5 +1,7 @@
 {
   "resetLayout": "将清空本区域全部建筑，是否确定？.",
+  "deleteAllBuildings": "删除本区域全部建筑，是否确定？",
+  "deleteAllRoads": "删除本区域全部道路，是否确定？",
   "maintenance": "维护",
   "space": "太空",
   "factories": "工厂",


### PR DESCRIPTION
I'm not sure about this one, I used it once or twice. Mostly to delete roads.
- Shift-click the delete-building or delete-road tool to clear all buildings or roads in the current sector (with a confirm).